### PR TITLE
Setup application performance monitoring

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ django-reversion==3.0.9
 django-staff-sso-client==3.1.0
 django-webpack-loader==0.7.0
 djangorestframework==3.12.2
+elastic-apm==6.2.0
 et-xmlfile==1.0.1
 factory-boy==3.2.0
 Faker==6.0.0

--- a/update_supply_chain_information/config/settings.py
+++ b/update_supply_chain_information/config/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     "django.contrib.postgres",
     "django.contrib.sessions",
     "django.contrib.staticfiles",
+    "elasticapm.contrib.django",
     "supply_chains",
     "accounts",
     "healthcheck",
@@ -46,6 +47,9 @@ INSTALLED_APPS = [
     "webpack_loader",
     "django.forms",
 ]
+
+# Elastic APM middleware automatically added to trace django requests
+# https://www.elastic.co/guide/en/apm/agent/python/current/configuration.html#config-django-autoinsert-middleware
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
@@ -211,3 +215,12 @@ CSRF_COOKIE_SECURE = env('CSRF_COOKIE_SECURE', default=True)
 CSRF_COOKIE_HTTPONLY = env('CSRF_COOKIE_HTTPONLY', default=True)
 SESSION_COOKIE_SECURE = env('SESSION_COOKIE_SECURE', default=True)
 SESSION_COOKIE_AGE = env('SESSION_COOKIE_AGE', default=60 * 60 * 10)
+
+# Settings for application performance monitoring
+ELASTIC_APM = {
+  "SERVICE_NAME": "update-supply-chain-information",
+  "SECRET_TOKEN": env("APM_SECRET_TOKEN", default=""),
+  "SERVER_URL" : "https://apm.elk.uktrade.digital",
+  "ENVIRONMENT": env("APM_ENVIRONMENT", default=""),
+  "SERVER_TIMEOUT": env("APM_SERVER_TIMEOUT", default=""),
+}

--- a/update_supply_chain_information/config/settings.py
+++ b/update_supply_chain_information/config/settings.py
@@ -53,6 +53,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "config.middleware.add_cache_control_header_middleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -60,7 +61,6 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "whitenoise.middleware.WhiteNoiseMiddleware",
     "reversion.middleware.RevisionMiddleware",
 ]
 

--- a/update_supply_chain_information/supply_chains/test/test_middleware.py
+++ b/update_supply_chain_information/supply_chains/test/test_middleware.py
@@ -8,6 +8,7 @@ def test_correct_middleware_exists():
     assert settings.MIDDLEWARE == [
         "elasticapm.contrib.django.middleware.TracingMiddleware",
         "django.middleware.security.SecurityMiddleware",
+        "whitenoise.middleware.WhiteNoiseMiddleware",
         "config.middleware.add_cache_control_header_middleware",
         "django.contrib.sessions.middleware.SessionMiddleware",
         "django.middleware.common.CommonMiddleware",
@@ -15,7 +16,6 @@ def test_correct_middleware_exists():
         "django.contrib.auth.middleware.AuthenticationMiddleware",
         "django.contrib.messages.middleware.MessageMiddleware",
         "django.middleware.clickjacking.XFrameOptionsMiddleware",
-        "whitenoise.middleware.WhiteNoiseMiddleware",
         "reversion.middleware.RevisionMiddleware",
     ]
 

--- a/update_supply_chain_information/supply_chains/test/test_middleware.py
+++ b/update_supply_chain_information/supply_chains/test/test_middleware.py
@@ -4,9 +4,9 @@ from django.urls import reverse
 
 from config import settings
 
-
 def test_correct_middleware_exists():
     assert settings.MIDDLEWARE == [
+        "elasticapm.contrib.django.middleware.TracingMiddleware",
         "django.middleware.security.SecurityMiddleware",
         "config.middleware.add_cache_control_header_middleware",
         "django.contrib.sessions.middleware.SessionMiddleware",


### PR DESCRIPTION
This PR adds configuration to enable Application Performance Monitoring via Elastic APM. This is one of the points in the 'Operations' section of the [Go live checklist](https://readme.trade.gov.uk/docs/procedures/1st-go-live.html#operations). This allows for monitoring of the application within ELK.

I have deployed this branch on the dev environment and you can see the monitoring dashboard [here in ELK](https://elk.uktrade.digital/app/apm/services/update-supply-chain-information/overview?rangeFrom=now-24h&rangeTo=now&latencyAggregationType=avg) - request access from SRE if needed.

I have also added the appropriate environment variables to dev, staging and production areas of [Vault](https://vault.ci.uktrade.digital/ui/vault/secrets/dit%2Fsupply-chain-resilience/list/update-supply-chain-information/).

When adding the elastic apm middleware to `test_middleware` it was noted that the whitenoise middleware is instructed to be under the django security middleware [in their docs](http://whitenoise.evans.io/en/stable/django.html#enable-whitenoise) - so this PR also includes moving it up the list.