### PR TITLE
Add scripts for google tag manager

### DIFF
--- a/update_supply_chain_information/supply_chains/templates/base.html
+++ b/update_supply_chain_information/supply_chains/templates/base.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 {% load render_bundle from webpack_loader %}
 {% load webpack_static from webpack_loader %}
+{% load supply_chain_filters %}
 <html lang="en" class="govuk-template ">
 
 <head>
@@ -12,9 +13,22 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{% webpack_static 'favicon.ico' %}" type="image/x-icon"/>
     {% render_bundle 'main' 'css' %}
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl+'{{ "GTM_AUTH_STRING"|env }}';f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-M5ZZ7ZS');</script>
+    <!-- End Google Tag Manager -->
 </head>
 
 <body class="govuk-template__body govuk-body">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript>
+        <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M5ZZ7ZS&{{ 'GTM_AUTH_STRING'|env }}"
+        height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <script>
         document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>   
@@ -77,4 +91,3 @@
 
     {% render_bundle 'main' 'js' %}
 </body>
-

--- a/update_supply_chain_information/supply_chains/templatetags/supply_chain_filters.py
+++ b/update_supply_chain_information/supply_chains/templatetags/supply_chain_filters.py
@@ -1,0 +1,7 @@
+import os
+
+from django.template.defaulttags import register
+
+@register.filter
+def env(key):
+    return os.environ.get(key, "")


### PR DESCRIPTION
This PR adds the `<script>` and `<noscript>` tags recommended by the performance analysis team to the head and body of the base template. This will allow the app to send events to google tag manager.

As the auth string for google tag manager is different for each environment (and there isn't one for production), I have made it an environment variable called `GTM_AUTH_STRING`.

To allow the base template to access this env var, I've created a custom template filter which will provide the value for a given environment variable.