### PR TITLE
RT-305: Fix/enable tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,13 @@ create-db: setup
 drop-db: setup
 	docker-compose exec -T db psql -h localhost -U postgres -c "DROP DATABASE supply_chain_info"
 
+create-test-db: setup
+	docker-compose exec -T db psql -h localhost -U postgres -c "CREATE DATABASE test_supply_chain_info WITH OWNER postgres ENCODING 'UTF8';"
+	make setup-db
+
+drop-test-db: setup
+	docker-compose exec -T db psql -h localhost -U postgres -c "DROP DATABASE test_supply_chain_info"
+
 tests:
 	pytest update_supply_chain_information
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ tests:
 
 load-data: setup
 	python update_supply_chain_information/manage.py loaddata cypress/fixtures/*.json
-	python update_supply_chain_information/manage.py datafixup --dev
+	python update_supply_chain_information/manage.py datafixup --noinput
 
 functional-tests:
 	bash run_functional_tests.sh

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ setup-db: setup
 	make load-data
 
 create-db: setup
-	docker-compose exec db psql -h localhost -U postgres -c "CREATE DATABASE supply_chain_info WITH OWNER postgres ENCODING 'UTF8';"
+	docker-compose exec -T db psql -h localhost -U postgres -c "CREATE DATABASE supply_chain_info WITH OWNER postgres ENCODING 'UTF8';"
 	make setup-db
 
 drop-db: setup
-	docker-compose exec db psql -h localhost -U postgres -c "DROP DATABASE supply_chain_info"
+	docker-compose exec -T db psql -h localhost -U postgres -c "DROP DATABASE supply_chain_info"
 
 tests:
 	pytest update_supply_chain_information

--- a/run_functional_tests.sh
+++ b/run_functional_tests.sh
@@ -11,7 +11,8 @@ docker-compose -f docker-compose.yaml -f docker-compose.override.yaml up -d
 export SET_HSTS_HEADERS='False'
 
 # reset db before test run
-make drop-db && make create-db
+make drop-db
+make create-db
 
 python update_supply_chain_information/manage.py runserver \
     --settings=test_settings \

--- a/run_functional_tests.sh
+++ b/run_functional_tests.sh
@@ -11,8 +11,7 @@ docker-compose -f docker-compose.yaml -f docker-compose.override.yaml up -d
 export SET_HSTS_HEADERS='False'
 
 # reset db before test run
-make drop-db
-make create-db
+make drop-db || make create-db
 
 python update_supply_chain_information/manage.py runserver \
     --settings=test_settings \

--- a/run_functional_tests.sh
+++ b/run_functional_tests.sh
@@ -11,7 +11,8 @@ docker-compose -f docker-compose.yaml -f docker-compose.override.yaml up -d
 export SET_HSTS_HEADERS='False'
 
 # reset db before test run
-make drop-db || make create-db
+make drop-db || true
+make create-db
 
 python update_supply_chain_information/manage.py runserver \
     --settings=test_settings \

--- a/run_functional_tests.sh
+++ b/run_functional_tests.sh
@@ -9,10 +9,9 @@ docker-compose -f docker-compose.yaml -f docker-compose.override.yaml up -d
 # Save the pid for the server to a file 'backend.pid'
 # Run all cypress tests after a 5 second delay to allow the django server to be brought up
 export SET_HSTS_HEADERS='False'
+export DATABASE_URL=postgres://postgres:password@localhost:5432/test_supply_chain_info
 
-# reset db before test run
-make drop-db || true
-make create-db
+make create-test-db
 
 python update_supply_chain_information/manage.py runserver \
     --settings=test_settings \
@@ -26,7 +25,7 @@ if [ "$running_locally" == true ]; then
     # Kill the application using the pid previously saved
     kill $(cat backend.pid)
     # Drop the test database
-    make drop-db && make create-db
+    make drop-test-db
 fi
 
 exit $cypress_failed

--- a/update_supply_chain_information/supply_chains/management/commands/datafixup.py
+++ b/update_supply_chain_information/supply_chains/management/commands/datafixup.py
@@ -32,7 +32,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, **options):
-        db_instance = "Dev"
+        db_name = connection.settings_dict['NAME']
 
         if not options["noinput"]:
             if not self.get_confirmtion():
@@ -41,7 +41,7 @@ class Command(BaseCommand):
         months_to_add = relativedelta(months=self.calculate_months_to_add())
         updates = StrategicActionUpdate.objects.all()
         self.update_submission_and_created_dates(updates, months_to_add)
-        self.stdout.write(self.style.SUCCESS(f"Fixtures fixed on {db_instance} db"))
+        self.stdout.write(self.style.SUCCESS(f"Fixtures fixed on {db_name} db"))
 
     def update_submission_and_created_dates(self, updates, months_to_add):
         updated_updates = []

--- a/update_supply_chain_information/supply_chains/management/commands/datafixup.py
+++ b/update_supply_chain_information/supply_chains/management/commands/datafixup.py
@@ -10,20 +10,33 @@ Status = StrategicActionUpdate.Status
 
 
 class Command(BaseCommand):
+    """Utility to manipulate sample data/fixtures
+
+    Note: This command will write into database and update mostly date related fileds.
+    Hence care must be taken while running this command.
+    """
+
     BASE_DATE = date(year=2021, month=5, day=1)
 
+    def get_confirmtion(self):
+        answer = ""
+        while answer not in ["y", "n"]:
+            answer = input("Continue to modify exisitng data [Y/N]? ").lower()
+        return answer == "y"
+
     def add_arguments(self, parser):
-        parser.add_argument("--dev", action="store_true")
+        parser.add_argument(
+            "--noinput",
+            action="store_true",
+            help="do not prompt for confimation",
+        )
 
     def handle(self, **options):
         db_instance = "Dev"
 
-        if not options["dev"]:
-            if "TEST" not in connection.creation.connection.settings_dict:
-                connection.creation.connection.settings_dict["TEST"] = {}
-            connection.creation.connection.settings_dict["TEST"]["MIGRATE"] = False
-            connection.creation.create_test_db(keepdb=True)
-            db_instance = "Test"
+        if not options["noinput"]:
+            if not self.get_confirmtion():
+                return
 
         months_to_add = relativedelta(months=self.calculate_months_to_add())
         updates = StrategicActionUpdate.objects.all()

--- a/update_supply_chain_information/supply_chains/test/test_fixture_fixup.py
+++ b/update_supply_chain_information/supply_chains/test/test_fixture_fixup.py
@@ -14,13 +14,6 @@ from supply_chains.management.commands.datafixup import Command
 pytestmark = pytest.mark.django_db
 
 
-@pytest.fixture(scope="function")
-def django_db_setup(django_db_setup, django_db_blocker):
-    with django_db_blocker.unblock():
-        call_command("datafixup")
-
-
-@pytest.mark.skip
 class TestFixtureFixup:
     ROOT_DIR = settings.BASE_DIR.parent
     fixtures = [
@@ -58,7 +51,7 @@ class TestFixtureFixup:
             "supply_chains.management.commands.datafixup.date",
             mock.Mock(today=mock.Mock(return_value=base_date)),
         ):
-            out = self.call_command()
+            self.call_command()
             updated_submission_dates = {
                 sau.pk: sau.submission_date
                 for sau in StrategicActionUpdate.objects.all()
@@ -132,7 +125,7 @@ class TestFixtureFixup:
             "supply_chains.management.commands.datafixup.date",
             mock.Mock(today=mock.Mock(return_value=base_date)),
         ):
-            out = self.call_command()
+            self.call_command()
             updated_submission_dates = {
                 sau.pk: sau.submission_date
                 for sau in StrategicActionUpdate.objects.all()
@@ -169,7 +162,7 @@ class TestFixtureFixup:
             "supply_chains.management.commands.datafixup.date",
             mock.Mock(today=mock.Mock(return_value=base_date)),
         ):
-            out = self.call_command()
+            self.call_command()
             updated_submission_dates = {
                 sau.pk: sau.submission_date
                 for sau in StrategicActionUpdate.objects.all()

--- a/update_supply_chain_information/supply_chains/test/test_fixture_fixup.py
+++ b/update_supply_chain_information/supply_chains/test/test_fixture_fixup.py
@@ -26,7 +26,9 @@ class TestFixtureFixup:
 
     def call_command(self, *args, **kwargs):
         out = StringIO()
-        call_command("datafixup", *args, stdout=out, stderr=StringIO(), **kwargs)
+        call_command(
+            "datafixup", "--noinput", *args, stdout=out, stderr=StringIO(), **kwargs
+        )
         return out.getvalue()
 
     def test_updates_in_month_of_base_date(self):


### PR DESCRIPTION
**Changes**
- Re-enable _datafixup_ tests
- Ask for confirmation while fixing data  using _datafixup_
- To alleviate testDB related over-rides to Django's internal working, using dev-server/dev-db for running functional tests.
- Reset DB before and after running functional tests
- Disable TTY for _exec_ commands within docker container(to work in GHA)