### PR TITLE
Set required fields for createsuperuser command

### DIFF
--- a/update_supply_chain_information/accounts/models.py
+++ b/update_supply_chain_information/accounts/models.py
@@ -77,6 +77,7 @@ class User(AbstractBaseUser, PermissionsMixin):
         "Unselect this instead of deleting accounts.",
     )
     USERNAME_FIELD = "sso_email_user_id"
+    REQUIRED_FIELDS = ["email", "first_name", "last_name"]
 
     def __str__(self):
         return f"{self.first_name} {self.last_name}"


### PR DESCRIPTION
**Purpose of PR**
As part of writing documentation for the project to be supported out of hours, I noticed that when running our `manage.py createsuperuser` command in the terminal, it raised the error that an email wasn't provided for the user.

This PR sets the `REQUIRED_FIELDS` attribute on the User model, which determines what fields are requested when the `createsuperuser` command is run. [Docs here](https://docs.djangoproject.com/en/3.2/topics/auth/customizing/#django.contrib.auth.models.CustomUser.REQUIRED_FIELDS).

**To test**
- Pull branch and run `python update_supply_chain_information/manage.py createsuperuser`
- You should be asked for an sso_email_user_id, email, first_name, last_name and password