### PR TITLE
Display action name in monthly update page headers

### DIFF
--- a/cypress/integration/monthly_update_forms_no_completion_date_spec.js
+++ b/cypress/integration/monthly_update_forms_no_completion_date_spec.js
@@ -48,6 +48,7 @@ const strategicActionsForTest = strategicActions.reduce((accumulator, action) =>
         'strategicActionSlug': action.fields.slug,
         'updateSlug': update.fields.slug,
         'updateContent': update.fields.content,
+        'name': action.fields.name
       };
     } else if (/^Has no update/.test(action.fields.description)) {
       const supplyChain = supplyChainsByPK[action.fields.supply_chain];
@@ -249,8 +250,8 @@ describe('Testing monthly update forms', () => {
             })
           })
           context('The Update Info page content', function() {
-            it('has the correct page header', () => {
-              cy.monthlyUpdatePageHeader().should('exist')
+            it('has the correct page header', function() {
+              cy.monthlyUpdatePageHeader(this.strategicAction.name).should('exist')
             })
             it('shows the previous update', function() {
               cy.get('.app-dit-panel h2:first').contains('Last update')
@@ -354,8 +355,8 @@ describe('Testing monthly update forms', () => {
             })
           })
           context('The Timing page content', function() {
-            it('has the correct page header', () => {
-              cy.monthlyUpdatePageHeader().should('exist')
+            it('has the correct page header', function() {
+              cy.monthlyUpdatePageHeader(this.strategicAction.name).should('exist')
             })
             it ('warns that there is no expected completion date', () => {
               cy.get('h1 ~ .govuk-warning-text').contains("There's no expected completion date for this action.").should('exist')
@@ -561,8 +562,8 @@ describe('Testing monthly update forms', () => {
             })
           })
           context('The Delivery Status page content', function() {
-            it('has the correct page header', () => {
-              cy.monthlyUpdatePageHeader().should('exist')
+            it('has the correct page header', function() {
+              cy.monthlyUpdatePageHeader(this.strategicAction.name).should('exist')
             })
             it ('warns that there is no expected completion date', () => {
               cy.get('body').get('h1 ~ .govuk-warning-text').contains("There's no expected completion date for this action.").should('exist')
@@ -742,8 +743,8 @@ describe('Testing monthly update forms', () => {
             })
           })
           context('The Check Your Answers page content should include', function() {
-            it('the correct page header', () => {
-              cy.monthlyUpdatePageHeader()
+            it('the correct page header', function() {
+              cy.monthlyUpdatePageHeader(this.strategicAction.name)
             })
             it('a medium-sized heading saying "Check your answers', () => {
               cy.govukMain().get('h2').should('have.class', 'govuk-heading-m').contains('Check your answers').should('exist')

--- a/cypress/integration/monthly_update_forms_with_completion_date_spec.js
+++ b/cypress/integration/monthly_update_forms_with_completion_date_spec.js
@@ -25,6 +25,7 @@ const strategicActionsForTest = strategicActions.reduce((accumulator, action) =>
         'updateSlug': update.fields.slug,
         'updateContent': update.fields.content,
         'targetCompletionDate': action.fields.target_completion_date,
+        'name': action.fields.name
       };
     } else if (/^Has no update/.test(action.fields.description)) {
       const supplyChain = supplyChainsByPK[action.fields.supply_chain];
@@ -255,8 +256,8 @@ describe('Testing monthly update forms', () => {
             })
           })
           context('The Update Info page content', function() {
-            it('has the correct page header', () => {
-              cy.monthlyUpdatePageHeader().should('exist')
+            it('has the correct page header', function() {
+              cy.monthlyUpdatePageHeader(this.strategicAction.name).should('exist')
             })
             it('shows the previous update', function() {
               cy.get('.app-dit-panel h2:first').contains('Last update')
@@ -353,8 +354,8 @@ describe('Testing monthly update forms', () => {
             })
           })
           context('The Delivery Status page content', function() {
-            it('has the correct page header', () => {
-              cy.monthlyUpdatePageHeader().should('exist')
+            it('has the correct page header', function() {
+              cy.monthlyUpdatePageHeader(this.strategicAction.name).should('exist')
             })
             it ('shows the expected completion date', function() {
               cy.get('h1 ~ .govuk-inset-text > h2').contains("Current estimated date of completion").should('exist')
@@ -608,8 +609,8 @@ describe('Testing monthly update forms', () => {
             })
           })
           context('The Revised Timing page content', function() {
-            it('has the correct page header', () => {
-              cy.monthlyUpdatePageHeader().should('exist')
+            it('has the correct page header', function() {
+              cy.monthlyUpdatePageHeader(this.strategicAction.name).should('exist')
             })
             it ('shows the expected completion date', function() {
               cy.get('h1 ~ .govuk-inset-text > h2').contains("Current estimated date of completion").should('exist')
@@ -819,8 +820,8 @@ describe('Testing monthly update forms', () => {
             })
           })
           context('The Check Your Answers page content should include', function() {
-            it('the correct page header', () => {
-              cy.monthlyUpdatePageHeader()
+            it('the correct page header', function() {
+              cy.monthlyUpdatePageHeader(this.strategicAction.name)
             })
             it('a medium-sized heading saying "Check your answers', () => {
               cy.govukMain().get('h2').should('have.class', 'govuk-heading-m').contains('Check your answers').should('exist')
@@ -954,10 +955,3 @@ describe('Testing monthly update forms', () => {
     })
   })
 })
-
-
-// describe('Testing validation errors in the monthly update forms', () => {
-//   context('for a strategic action', function() {
-//       context('that does have a target completion date', function() {})
-//   })
-// })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,8 +1,8 @@
 Cypress.Commands.add(
     'monthlyUpdatePageHeader',
-    {prevSubject: false,},
-    () => {
-        cy.govukMain().find('h1').contains('Strategic action monthly update')
+    {prevSubject: false},
+    (actionName) => {
+        return cy.govukMain().find('h1').contains(`Monthly update for ${actionName}`)
     }
 )
 

--- a/update_supply_chain_information/supply_chains/templates/supply_chains/monthly_update_form_base.html
+++ b/update_supply_chain_information/supply_chains/templates/supply_chains/monthly_update_form_base.html
@@ -8,6 +8,6 @@
 
 {% block body %}
     {% include "supply_chains/includes/error_summary.html" %}
-    <h1 class="govuk-heading-xl">Strategic action monthly update</h1>
+    <h1 class="govuk-heading-xl">Monthly update for {{ strategic_action_update.strategic_action.name }}</h1>
     {% block form %}{% endblock form %}
 {% endblock body %}

--- a/update_supply_chain_information/supply_chains/templates/supply_chains/monthly_update_summary.html
+++ b/update_supply_chain_information/supply_chains/templates/supply_chains/monthly_update_summary.html
@@ -8,7 +8,7 @@
 
 {% block body %}
     {% include "supply_chains/includes/summary_page_error_summary.html" %}
-    <h1 class="govuk-heading-xl">Strategic action monthly update</h1>
+    <h1 class="govuk-heading-xl">Monthly update for {{ strategic_action_update.strategic_action.name }}</h1>
     <h2 class="govuk-heading-m">Check your answers</h2>
     <p class="govuk-body">Check all the information you've provided is correct before confirming.</p>
     {# Always include the content form #}


### PR DESCRIPTION
This PR updates the header of the monthly update pages to show 'Monthly update for [strategic action name]'.

In order to update the functional tests, the PR updates the custom cypress command `cy.monthlyUpdatePageHeader` to accept an argument (the name of a strategic action).

**New header**

![Screenshot 2021-06-08 at 15 14 31](https://user-images.githubusercontent.com/22460823/121337670-ae8df580-c914-11eb-8137-0c4da6d294d0.png)
