### PR TITLE
Add custom access denied page

### DIFF
--- a/cypress/fixtures/govDepartment.json
+++ b/cypress/fixtures/govDepartment.json
@@ -6,5 +6,13 @@
       "name": "DIT",
       "email_domains": ["trade.gov.uk", "digital.trade.gov.uk"]
     }
+  },
+  {
+    "model": "accounts.govdepartment",
+    "pk": "35727354-6698-4586-9b78-a0f426b86bc9",
+    "fields": {
+      "name": "Another department",
+      "email_domains": ["dep.gov.uk"]
+    }
   }
 ]

--- a/cypress/fixtures/supplyChains.json
+++ b/cypress/fixtures/supplyChains.json
@@ -112,5 +112,23 @@
       "is_archived": false,
       "archived_date": null
     }
+  },
+  {
+    "model": "supply_chains.supplychain",
+    "pk": "932b784f-77fe-40d0-ab1b-cba4bef16c77",
+    "fields": {
+      "name": "Supply chain of other dep",
+      "last_submission_date": "2021-04-01",
+      "gov_department": "35727354-6698-4586-9b78-a0f426b86bc9",
+      "contact_name": "nobody",
+      "contact_email": "nobody@dep.gov.uk",
+      "vulnerability_status": "low",
+      "vulnerability_status_disagree_reason": "",
+      "risk_severity_status": "low",
+      "risk_severity_status_disagree_reason": "",
+      "slug": "supply-chain-of-other-dep",
+      "is_archived": false,
+      "archived_date": null
+    }
   }
 ]

--- a/cypress/fixtures/user.json
+++ b/cypress/fixtures/user.json
@@ -9,5 +9,18 @@
       "gov_department": "15fb0d63-2ee6-4652-8acd-222bd2718703",
       "is_superuser": "True"
     }
+  },
+  {
+    "model": "accounts.user",
+    "pk": "a4ba6142-b4f2-4338-b65c-c8b1f5055815",
+    "fields": {
+      "sso_email_user_id": "admin.user-1@id.mock-sso",
+      "first_name": "Admin user",
+      "last_name": "Holland",
+      "email": "admin.user@email.com",
+      "gov_department": "15fb0d63-2ee6-4652-8acd-222bd2718703",
+      "is_superuser": "True",
+      "receive_feedback_emails": "True"
+    }
   }
 ]

--- a/cypress/integration/access_denied_spec.js
+++ b/cypress/integration/access_denied_spec.js
@@ -1,0 +1,29 @@
+import supplyChains from '../fixtures/supplyChains.json'
+import users from '../fixtures/user.json'
+
+const supplyChain = supplyChains[7].fields
+const adminUser = users[1].fields
+
+describe('The access denied page', () => {
+  it('successfully loads', () => {
+    cy.visit(Cypress.config('baseUrl') + `/${supplyChain.slug}/`, {failOnStatusCode: false})
+    cy.injectAxe()
+  })
+  it('has no accessibility issues', () => {
+    cy.runA11y()
+  })
+  it('Displays the correct text', () => {
+      cy.get('h1').contains('Access denied')
+      cy.get('p').contains('You do not have permission to access this page.')
+      cy.get('p').contains('Please try one of the following:')
+      cy.get('ul').children().should('have.length', 4)
+      cy.get('li').contains('If you typed the web address, check it is correct')
+      cy.get('li').contains('If you pasted the web address, check you copied the entire address')
+      cy.get('li').contains('Browse the homepage to find the information you need')
+      cy.get('li').contains('Contact the Resilience Tool team if you think you do have permission to access this page.')
+  })
+  it('Displays correct links', () => {
+      cy.get('a').contains('homepage').should('have.attr', 'href').and('eq', '/')
+      cy.get('a').contains('Contact the Resilience Tool team').should('have.attr', 'href').and('eq', `mailto:${adminUser.email}`)
+  })
+})

--- a/update_supply_chain_information/supply_chains/templates/403.html
+++ b/update_supply_chain_information/supply_chains/templates/403.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+
+{% block body %}
+<h1 class="govuk-heading-xl">Access denied</h1>
+<p class="govuk-body">You do not have permission to access this page.</p>
+<p class="govuk-body">
+    Please try one of the following:
+    <ul class="govuk-list govuk-list--bullet">
+        <li>If you typed the web address, check it is correct</li>
+        <li>If you pasted the web address, check you copied the entire address</li>
+        <li>
+            Browse the <a class="govuk-link" href="{% url 'index' %}">homepage</a>
+             to find the information you need</li>
+        {% get_feedback_emails_as_string as feedback_emails %}
+        <li>
+            <a class="govuk-link" href="mailto:{{ feedback_emails }}">Contact the Resilience Tool team</a>
+             if you think you do have permission to access this page.
+        </li>
+    </ul>
+</p>
+
+{% endblock %}

--- a/update_supply_chain_information/supply_chains/templates/base.html
+++ b/update_supply_chain_information/supply_chains/templates/base.html
@@ -2,6 +2,7 @@
 {% load render_bundle from webpack_loader %}
 {% load webpack_static from webpack_loader %}
 {% load supply_chain_filters %}
+{% load supply_chain_tags %}
 <html lang="en" class="govuk-template ">
 
 <head>

--- a/update_supply_chain_information/supply_chains/templates/task_complete.html
+++ b/update_supply_chain_information/supply_chains/templates/task_complete.html
@@ -38,7 +38,7 @@
     </p>
 
     <p class="govuk-body">
-        Your update has been sent to the Global Supply Chains team who will use this data to inform Programme Broad decision making.
+        Your update has been sent to the Global Supply Chains team who will use this data to inform Programme Board decision making.
     </p>
 
     <p class="govuk-body">

--- a/update_supply_chain_information/supply_chains/templatetags/supply_chain_tags.py
+++ b/update_supply_chain_information/supply_chains/templatetags/supply_chain_tags.py
@@ -1,0 +1,11 @@
+from django.template.defaulttags import register
+
+from accounts.models import User
+
+
+@register.simple_tag
+def get_feedback_emails_as_string() -> str:
+    """Formats emails as comma separated string to be passed to a mailto link"""
+    users = User.objects.filter(receive_feedback_emails=True)
+    emails = [user.email for user in users]
+    return ",".join(emails)


### PR DESCRIPTION
This PR creates a custom access denied page, returned whenever the `PermissionDenied` exception is raised. 

Django automatically renders a template with the name `403.html` (if it exists) when `PermissionDenied` is raised.

This page will be shown if a user tries to access a URL not related to an object linked to their gov department - e.g. a supply chain their department isn't responsible for.

In order to feed the feedback email addresses to the `mailto:` link in the 403 template, I have added a template tag which will return the email addresses of all users with `receive_feedback_emails` as True, as a comma separated string.

**Access denied page**
![Screenshot 2021-06-14 at 11 16 47](https://user-images.githubusercontent.com/22460823/121876978-04daaa00-cd02-11eb-8b94-b4b900f10663.png)


