### PR TITLE
Add feedback link & fix alignment in BETA banner

### DIFF
--- a/cypress/integration/access_denied_spec.js
+++ b/cypress/integration/access_denied_spec.js
@@ -24,6 +24,6 @@ describe('The access denied page', () => {
   })
   it('Displays correct links', () => {
       cy.get('a').contains('homepage').should('have.attr', 'href').and('eq', '/')
-      cy.get('a').contains('Contact the Resilience Tool team').should('have.attr', 'href').and('eq', `mailto:${adminUser.email}`)
+      cy.get('a').contains('Contact the Resilience Tool team').should('have.attr', 'href').and('eq', `mailto:${Cypress.env('FEEDBACK_GROUP_EMAIL')}?bcc=${adminUser.email}`)
   })
 })

--- a/cypress/integration/home_page_spec.js
+++ b/cypress/integration/home_page_spec.js
@@ -2,6 +2,7 @@ import users from '../fixtures/user.json'
 import govDepartments from '../fixtures/govDepartment.json'
 
 const user = users[0].fields
+const adminUser = users[1].fields
 const govDepartment = govDepartments[0].fields
 
 describe('The Home Page', () => {
@@ -17,6 +18,12 @@ describe('The Home Page', () => {
       'have.text',
       `${user.first_name} ${user.last_name} - ${govDepartment.name}`
     )
+  })
+  it("displays the BETA phase banner with feedback link", () => {
+    const bannerContents = cy.get('.govuk-phase-banner').children()
+    bannerContents.get('.govuk-phase-banner__content__tag').contains('beta')
+    bannerContents.get('.govuk-phase-banner__text').contains('This is a new service – your feedback will help us to improve it.')
+    bannerContents.get('a').contains('feedback').should('have.attr', 'href').and('eq', `mailto:${adminUser.email}`)
   })
   it('displays the correct text', () => {
     cy.get('h1').contains(

--- a/cypress/integration/home_page_spec.js
+++ b/cypress/integration/home_page_spec.js
@@ -23,7 +23,7 @@ describe('The Home Page', () => {
     const bannerContents = cy.get('.govuk-phase-banner').children()
     bannerContents.get('.govuk-phase-banner__content__tag').contains('beta')
     bannerContents.get('.govuk-phase-banner__text').contains('This is a new service – your feedback will help us to improve it.')
-    bannerContents.get('a').contains('feedback').should('have.attr', 'href').and('eq', `mailto:${adminUser.email}`)
+    bannerContents.get('a').contains('feedback').should('have.attr', 'href').and('eq', `mailto:${Cypress.env('FEEDBACK_GROUP_EMAIL')}?bcc=${adminUser.email}`)
   })
   it('displays the correct text', () => {
     cy.get('h1').contains(

--- a/run_functional_tests.sh
+++ b/run_functional_tests.sh
@@ -10,6 +10,9 @@ docker-compose -f docker-compose.yaml -f docker-compose.override.yaml up -d
 # Run all cypress tests after a 5 second delay to allow the django server to be brought up
 export SET_HSTS_HEADERS='False'
 export DATABASE_URL=postgres://postgres:password@localhost:5432/test_supply_chain_info
+export FEEDBACK_GROUP_EMAIL=feedback@email
+# Accessible by Cypress.env()
+export CYPRESS_FEEDBACK_GROUP_EMAIL=feedback@email
 
 make create-test-db
 

--- a/update_supply_chain_information/assets/stylesheets/application.scss
+++ b/update_supply_chain_information/assets/stylesheets/application.scss
@@ -22,10 +22,6 @@ $govuk-image-url-function: frontend-image-url;
   margin: 0;
 }
 
-.app-phase-banner-content {
-  display: inline;
-}
-
 .app-switch-to-tool-link {
   float: right;
   padding-top: 4px;

--- a/update_supply_chain_information/sample.env
+++ b/update_supply_chain_information/sample.env
@@ -18,3 +18,6 @@ CSRF_COOKIE_HTTPONLY=False
 SESSION_COOKIE_SECURE=False
 # Optional, defaults to 36000 (10 hours)
 # SESSION_COOKIE_AGE=
+
+# Optional when running locally
+#FEEDBACK_GROUP_EMAIL=

--- a/update_supply_chain_information/supply_chains/templates/403.html
+++ b/update_supply_chain_information/supply_chains/templates/403.html
@@ -13,7 +13,7 @@
              to find the information you need</li>
         {% get_feedback_emails_as_string as feedback_emails %}
         <li>
-            <a class="govuk-link" href="mailto:{{ feedback_emails }}">Contact the Resilience Tool team</a>
+            <a class="govuk-link" href="mailto:{{ 'FEEDBACK_GROUP_EMAIL'|env }}?bcc={{ feedback_emails }}">Contact the Resilience Tool team</a>
              if you think you do have permission to access this page.
         </li>
     </ul>

--- a/update_supply_chain_information/supply_chains/templates/base.html
+++ b/update_supply_chain_information/supply_chains/templates/base.html
@@ -53,8 +53,9 @@
                     <strong class="govuk-tag govuk-phase-banner__content__tag">
                         beta
                     </strong>
+                    {% get_feedback_emails_as_string as feedback_emails %}
                     <span class="govuk-phase-banner__text">
-                        This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.
+                        This is a new service – your <a class="govuk-link" href="mailto:{{ feedback_emails }}">feedback</a> will help us to improve it.
                     </span>
                 </span>
             </p>

--- a/update_supply_chain_information/supply_chains/templates/base.html
+++ b/update_supply_chain_information/supply_chains/templates/base.html
@@ -48,15 +48,13 @@
             </div>
         </div>
         <div class="govuk-phase-banner govuk-width-container">
-            <p class="govuk-phase-banner__content app-phase-banner-content">
-                <span>
-                    <strong class="govuk-tag govuk-phase-banner__content__tag">
-                        beta
-                    </strong>
-                    {% get_feedback_emails_as_string as feedback_emails %}
-                    <span class="govuk-phase-banner__text">
-                        This is a new service – your <a class="govuk-link" href="mailto:{{ feedback_emails }}">feedback</a> will help us to improve it.
-                    </span>
+            <p class="govuk-phase-banner__content">
+                <strong class="govuk-tag govuk-phase-banner__content__tag">
+                beta
+                </strong>
+                {% get_feedback_emails_as_string as feedback_emails %}
+                <span class="govuk-phase-banner__text">
+                    This is a new service – your <a class="govuk-link" href="mailto:{{ feedback_emails }}">feedback</a> will help us to improve it.
                 </span>
             </p>
         </div>

--- a/update_supply_chain_information/supply_chains/templates/base.html
+++ b/update_supply_chain_information/supply_chains/templates/base.html
@@ -54,7 +54,7 @@
                 </strong>
                 {% get_feedback_emails_as_string as feedback_emails %}
                 <span class="govuk-phase-banner__text">
-                    This is a new service – your <a class="govuk-link" href="mailto:{{ feedback_emails }}">feedback</a> will help us to improve it.
+                    This is a new service – your <a class="govuk-link" href="mailto:{{ 'FEEDBACK_GROUP_EMAIL'|env }}?bcc={{ feedback_emails }}">feedback</a> will help us to improve it.
                 </span>
             </p>
         </div>


### PR DESCRIPTION
This PR makes two changes to the BETA phase banner in the base template:

1. Adds a mailto link to 'feedback' which will open an email to a group email address with users with `receive_email_feedback` as True bcc'd.
2. Vertically centres the text in the banner (caused by an unneeded <span>)

It updates the feedback link in the 403 template to create the same email (group email in 'to' field, with admin users bcc'd)

It also removes the custom class `app-phase-banner-content` which is no longer needed (left over from when there was an additional link in the right of the banner).

**Updated banner**

![Screenshot 2021-06-14 at 15 27 25](https://user-images.githubusercontent.com/22460823/121908610-141f1f00-cd25-11eb-9b89-4207f91d8da4.png)
