### PR TITLE
Fix homepage content

### DIFF
--- a/cypress/integration/home_page_spec.js
+++ b/cypress/integration/home_page_spec.js
@@ -39,7 +39,7 @@ describe('The Home Page', () => {
     cy.get('li').contains(
       'Select a supply chain to provide your regular monthly update.'
     )
-    cy.get('li').contains(
+    cy.get('p').contains(
       'All supply chains have been completed for this month'
     ).should('not.exist')
 

--- a/update_supply_chain_information/supply_chains/templates/index.html
+++ b/update_supply_chain_information/supply_chains/templates/index.html
@@ -16,7 +16,7 @@
         <h2 class="govuk-heading-l">Complete your monthly update</h2>
         <ul class="govuk-list govuk-list--bullet">
             <li>
-                You need to complete your monthly update. Complete <strong>{{ num_in_prog_supply_chains }} supply chains</strong> by
+                You need to complete your monthly update. Complete <strong>{{ num_in_prog_supply_chains }} supply chain{{ num_in_prog_supply_chains|pluralize }}</strong> by
                 <span class="govuk-body govuk-!-font-weight-bold">{{ deadline|date:"l jS F Y" }}</span>.
             </li>
             <li>

--- a/update_supply_chain_information/supply_chains/templates/index.html
+++ b/update_supply_chain_information/supply_chains/templates/index.html
@@ -7,11 +7,9 @@
     </p>
     {% if update_complete %}
         <h2 class="govuk-heading-l">Your monthly update is complete</h2>
-        <ul class="govuk-list govuk-list--bullet">
-            <li>
-                All supply chains have been completed for this month.
-            </li>
-        </ul>
+        <p class="govuk-body">
+            All supply chains have been completed for this month.
+        </p>
     {% else %}
         <h2 class="govuk-heading-l">Complete your monthly update</h2>
         <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
This PR makes two fixes to content on the homepage:

1. It pluralises 'supply chain' only when there are more than 1 incomplete supply chains for that department
2. It moves the sentence 'All your supply chains are complete...' to a paragraph rather than a bullet point

**When all complete**

![Screenshot 2021-06-15 at 17 31 12](https://user-images.githubusercontent.com/22460823/122090460-af84c280-cdff-11eb-88a0-31c2241ae03b.png)

**When just 1 supply chain**

![Screenshot 2021-06-15 at 17 31 50](https://user-images.githubusercontent.com/22460823/122090489-b6133a00-cdff-11eb-975d-e4e84420adf5.png)

**When more than 1 supply chain**

![Screenshot 2021-06-15 at 17 32 13](https://user-images.githubusercontent.com/22460823/122090506-bb708480-cdff-11eb-9da3-472eeb3d6775.png)
