### PR TITLE
Filter out archived supply chains/strategic actions from views

### DIFF
--- a/update_supply_chain_information/supply_chains/test/test_views.py
+++ b/update_supply_chain_information/supply_chains/test/test_views.py
@@ -108,6 +108,21 @@ def test_homepage_update_incomplete(logged_in_client, test_user):
     )
 
 
+def test_homepage_filters_out_archived_supply_chains(logged_in_client, test_user):
+    gov_department = test_user.gov_department
+    # Create archived supply chains
+    SupplyChainFactory.create_batch(
+        5, gov_department=gov_department, is_archived=True, archived_reason="Reason"
+    )
+    # Create non archived supply chains
+    SupplyChainFactory.create_batch(5, gov_department=gov_department)
+
+    num_unarchived_supply_chains = SupplyChain.objects.filter(is_archived=False).count()
+    response = logged_in_client.get(reverse("index"))
+
+    assert len(response.context["supply_chains"]) == num_unarchived_supply_chains
+
+
 def test_strat_action_summary_page_unauthenticated(test_supply_chain):
     """Test unauthenticated request is redirected."""
     client = Client()

--- a/update_supply_chain_information/supply_chains/views.py
+++ b/update_supply_chain_information/supply_chains/views.py
@@ -153,25 +153,35 @@ class SCTaskListView(
             slug=supply_chain_slug, is_archived=False
         )
 
-        sa_qset = StrategicAction.objects.filter(supply_chain=self.supply_chain)
+        sa_qset = StrategicAction.objects.filter(
+            supply_chain=self.supply_chain, is_archived=False
+        )
         self.total_sa = sa_qset.count()
 
         self.sa_updates = self._get_sa_update_list(sa_qset)
 
-        self.ready_to_submit_updates = StrategicActionUpdate.objects.since(
-            self.last_deadline,
-            supply_chain=self.supply_chain,
-            status__in=[
-                StrategicActionUpdate.Status.READY_TO_SUBMIT,
-                StrategicActionUpdate.Status.SUBMITTED,
-            ],
-        ).count()
+        self.ready_to_submit_updates = (
+            StrategicActionUpdate.objects.since(
+                self.last_deadline,
+                supply_chain=self.supply_chain,
+                status__in=[
+                    StrategicActionUpdate.Status.READY_TO_SUBMIT,
+                    StrategicActionUpdate.Status.SUBMITTED,
+                ],
+            )
+            .filter(strategic_action__is_archived=False)
+            .count()
+        )
 
-        self.submitted_only_updates = StrategicActionUpdate.objects.since(
-            self.last_deadline,
-            supply_chain=self.supply_chain,
-            status=StrategicActionUpdate.Status.SUBMITTED,
-        ).count()
+        self.submitted_only_updates = (
+            StrategicActionUpdate.objects.since(
+                self.last_deadline,
+                supply_chain=self.supply_chain,
+                status=StrategicActionUpdate.Status.SUBMITTED,
+            )
+            .filter(strategic_action__is_archived=False)
+            .count()
+        )
 
         self.incomplete_updates = self.total_sa - self.ready_to_submit_updates
 

--- a/update_supply_chain_information/supply_chains/views.py
+++ b/update_supply_chain_information/supply_chains/views.py
@@ -44,7 +44,10 @@ class HomePageView(LoginRequiredMixin, PaginationMixin, ListView):
     template_name = "index.html"
 
     def get_queryset(self):
-        return self.request.user.gov_department.supply_chains.annotate(
+        supply_chains = self.request.user.gov_department.supply_chains.filter(
+            is_archived=False
+        )
+        return supply_chains.annotate(
             strategic_action_count=Count("strategic_actions")
         ).order_by("name")
 


### PR DESCRIPTION
This PR makes two fixes:

1. Filters out archived supply chains from the home page view
2. Filters out archived strategic actions from the task list view

I have also added a test for each of these scenarios to the relevant files.

In the `SCTaskListView` I have also filtered out archived strategic actions when calculating `self.ready_to_submit_updates` and `self.submitted_only_updates`. 

This means that the numbers displayed in `x out of x strategic actions are not ready to submit` in the template would remain correct even if an update was given for an action since the last deadline, but that action was then archived (and therefore would no longer appear in the task list)