### PR TITLE
RT-349: Fix homepage summary

### DIFF
--- a/update_supply_chain_information/supply_chains/views.py
+++ b/update_supply_chain_information/supply_chains/views.py
@@ -66,12 +66,18 @@ class HomePageView(LoginRequiredMixin, PaginationMixin, ListView):
         ).count()
         context["gov_department_name"] = self.request.user.gov_department.name
 
+        # Total supply chains are aways sum of supply chains with active SAs.
+        # Though SC with 0 active SA are listed, no action is required and hence not included
+        # for to be completed
+        total_sc_with_active_sa = self.object_list.filter(
+            strategic_actions__is_archived=False
+        ).count()
         context["update_complete"] = (
-            context["num_updated_supply_chains"] == self.object_list.count()
+            context["num_updated_supply_chains"] == total_sc_with_active_sa
         )
 
         context["num_in_prog_supply_chains"] = (
-            self.object_list.count() - context["num_updated_supply_chains"]
+            total_sc_with_active_sa - context["num_updated_supply_chains"]
         )
 
         return context


### PR DESCRIPTION
HomePage now factors in supply chain with active strategic actions while building summary data

**Changes**
- Update HomePage _get_context_data_ to count SCs with active SAs
- Tests

**Screenshots**

![image](https://user-images.githubusercontent.com/81681068/122932263-7e5b4380-d365-11eb-906b-1a0d2a7f4742.png)
 