### PR TITLE
RT-350: Exclude archived SC within SCCompleteView

### DIFF
--- a/update_supply_chain_information/supply_chains/test/test_taskcomplete_view.py
+++ b/update_supply_chain_information/supply_chains/test/test_taskcomplete_view.py
@@ -5,7 +5,7 @@ from django.test import Client
 from django.urls import reverse
 from django.template.defaultfilters import slugify
 
-from supply_chains.models import StrategicActionUpdate
+from supply_chains.models import StrategicActionUpdate, SupplyChain
 from supply_chains.test.factories import (
     SupplyChainFactory,
     StrategicActionFactory,
@@ -82,11 +82,29 @@ class TestTaskCompleteView:
         print(f'view: {resp.context["view"]}')
         assert resp.context["view"].supply_chain.name == taskcomp_stub["sc_name"]
 
-    def test_action_summary(self, logged_in_client, taskcomp_stub):
+    def test_SC_complete_summary(self, logged_in_client, taskcomp_stub):
         # Arrange
         # Act
         resp = logged_in_client.get(taskcomp_stub["url"])
 
         # Assert
+        assert resp.context["view"].sum_of_supply_chains == 3
+        assert resp.context["view"].num_updated_supply_chains == 1
+
+    def test_SC_complete_summary_with_archived(
+        self, logged_in_client, taskcomp_stub, test_user
+    ):
+        # Arrange
+        SupplyChainFactory.create(
+            is_archived=True,
+            archived_reason="reason",
+            gov_department=test_user.gov_department,
+        )
+
+        # Act
+        resp = logged_in_client.get(taskcomp_stub["url"])
+
+        # Assert
+        assert SupplyChain.objects.all().count() == 4
         assert resp.context["view"].sum_of_supply_chains == 3
         assert resp.context["view"].num_updated_supply_chains == 1

--- a/update_supply_chain_information/supply_chains/views.py
+++ b/update_supply_chain_information/supply_chains/views.py
@@ -267,7 +267,9 @@ class SCCompleteView(LoginRequiredMixin, GovDepPermissionMixin, TemplateView):
                 "supply-chain-task-list", supply_chain_slug=self.supply_chain.slug
             )
 
-        supply_chains = request.user.gov_department.supply_chains.order_by("name")
+        supply_chains = request.user.gov_department.supply_chains.filter(
+            is_archived=False
+        ).order_by("name")
 
         self.sum_of_supply_chains = supply_chains.count()
 


### PR DESCRIPTION
Yet another occurrence of incorrect summary message when archived SC is involved.

Applying the same fix to add a filter to exclude archived SC.

**Note**
As its a minor bug w/o any side affects, target branch is _develop_ intended for next release.