### PR TITLE
RT-415: Ensure the user is added to a Strategic Action Update when they start one

### DIFF
--- a/update_supply_chain_information/supply_chains/test/test_views.py
+++ b/update_supply_chain_information/supply_chains/test/test_views.py
@@ -854,3 +854,23 @@ class TestMonthlyUpdateFormPagesPermissions:
         )
         response = client.get(url)
         assert response.status_code == 403
+
+
+class TestMonthlyUpdateInfoCreateView:
+    def test_new_strategic_action_has_user_set(self, logged_in_client, test_user):
+        supply_chain = SupplyChainFactory()
+        strategic_action = StrategicActionFactory(supply_chain=supply_chain)
+        url = reverse(
+            "monthly-update-create",
+            kwargs={
+                "supply_chain_slug": supply_chain.slug,
+                "action_slug": strategic_action.slug,
+            },
+        )
+        test_user.gov_department = supply_chain.gov_department
+        test_user.save()
+        logged_in_client.get(url)
+        strategic_action_update = strategic_action.monthly_updates.order_by(
+            "-last_modified"
+        ).first()
+        assert strategic_action_update.user == test_user

--- a/update_supply_chain_information/supply_chains/views.py
+++ b/update_supply_chain_information/supply_chains/views.py
@@ -405,6 +405,7 @@ class MonthlyUpdateInfoCreateView(
                 strategic_action.monthly_updates.create(
                     status=StrategicActionUpdate.Status.IN_PROGRESS,
                     supply_chain=strategic_action.supply_chain,
+                    user=request.user,
                 )
             )
         update_url = reverse(


### PR DESCRIPTION
SAUs weren't saving the user that created them in their `user` field.