### PR TITLE
RT-434: Fix/activity stream data loss

### DIFF
--- a/update_supply_chain_information/activity_stream/models.py
+++ b/update_supply_chain_information/activity_stream/models.py
@@ -46,7 +46,7 @@ class ActivityStreamQuerySetMixin:
             # which in turn is necessary for delivering a feed containing all objects
             # ordered by their `last_modified` timestamps
             # without pulling everything into memory and processing it all there.
-            .values("last_modified", "json", "foreign_keys", "object_type")
+            .values("id", "last_modified", "json", "foreign_keys", "object_type")
         )
 
     def modified_after(self, datetime=datetime.datetime(year=1, month=1, day=1)):

--- a/update_supply_chain_information/activity_stream/pagination.py
+++ b/update_supply_chain_information/activity_stream/pagination.py
@@ -26,7 +26,10 @@ class ActivityStreamCursorPagination(CursorPagination):
     """
 
     summary = "Update Supply Chain Information"
-    ordering = ("last_modified",)
+    ordering = (
+        "last_modified",
+        "id",
+    )
 
     def paginate_queryset(self, queryset, request, view=None):
         """

--- a/update_supply_chain_information/activity_stream/test/test_pagination.py
+++ b/update_supply_chain_information/activity_stream/test/test_pagination.py
@@ -228,7 +228,7 @@ class TestActivityStreamCursorPagination:
             StrategicActionFactory.create_batch(
                 page_length * 2, supply_chain=supply_chain
             )
-            all_item_ids = {item.id for item in StrategicAction.objects.all()}
+            all_item_ids = {str(item.id) for item in StrategicAction.objects.all()}
             request = rf.get(reverse("activity-stream-list"))
             drf_request = Request(request)
             queryset = ActivityStreamQuerySetWrapper()
@@ -243,4 +243,4 @@ class TestActivityStreamCursorPagination:
                 next_page_item_ids = {item["json"]["id"] for item in next_page_items}
                 page_item_ids = page_item_ids | next_page_item_ids
                 next_link = pagination.get_next_link()
-            assert all_item_ids.issubset(next_page_item_ids)
+            assert all_item_ids.issubset(page_item_ids)


### PR DESCRIPTION
Some models have many instances with identical values for `last_modified`. The `activity_stream` pagination depends on ordering by that field. As the instances are unordered within the ordering by `last_modified`, it becomes possible for any given instance to appear on multiple pages, or not to appear on any page.

This can be addressed by adding `id` as a second-level ordering.