### PR TITLE
RT-484: Decrease the font size for notes within SAP details

### DIFF
--- a/update_supply_chain_information/action_progress/templates/includes/action_info.html
+++ b/update_supply_chain_information/action_progress/templates/includes/action_info.html
@@ -59,7 +59,7 @@
       </dd>
     </div>
     <div class="govuk-summary-list__row--no-border">
-        <dd class="govuk-summary-list__value" style="font-size: 16px;">
+        <dd class="govuk-summary-list__value govuk-!-font-size-16">
             {{ action.gsc_notes|default:"No recordings from GSC" }}
         </dd>
     </div>

--- a/update_supply_chain_information/action_progress/templates/includes/action_info.html
+++ b/update_supply_chain_information/action_progress/templates/includes/action_info.html
@@ -59,7 +59,7 @@
       </dd>
     </div>
     <div class="govuk-summary-list__row--no-border">
-        <dd class="govuk-summary-list__value">
+        <dd class="govuk-summary-list__value" style="font-size: 16px;">
             {{ action.gsc_notes|default:"No recordings from GSC" }}
         </dd>
     </div>

--- a/update_supply_chain_information/action_progress/templates/includes/monthly_update_details.html
+++ b/update_supply_chain_information/action_progress/templates/includes/monthly_update_details.html
@@ -36,7 +36,7 @@
                 </dd>
             </div>
             <div class="govuk-summary-list__row--no-border">
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value" style="font-size: 16px;">
                     Last updated on {{ update.submission_date|date:"l, M Y" }}
                 </dd>
             </div>

--- a/update_supply_chain_information/action_progress/templates/includes/monthly_update_details.html
+++ b/update_supply_chain_information/action_progress/templates/includes/monthly_update_details.html
@@ -36,7 +36,7 @@
                 </dd>
             </div>
             <div class="govuk-summary-list__row--no-border">
-                <dd class="govuk-summary-list__value" style="font-size: 16px;">
+                <dd class="govuk-summary-list__value govuk-!-font-size-16">
                     Last updated on {{ update.submission_date|date:"l, M Y" }}
                 </dd>
             </div>


### PR DESCRIPTION
Only change to decrease the font of _notes_ fields to 16 pixels