### PR TITLE
RT-566: Fix: ScenarioAssessment one-to-one fields in activity stream.

### DIFF
--- a/update_supply_chain_information/activity_stream/models.py
+++ b/update_supply_chain_information/activity_stream/models.py
@@ -13,17 +13,19 @@ class ActivityStreamQuerySetMixin:
         Convert a queryset into a form suitable for serialisation in the activity stream feed.
         """
         fields = self.model._meta.get_fields()
-        # Find all fields that are foreign keys, as their values will be adjusted on serialisation
+        # Find all fields that are foreign keys or one-to-one keys, as their values will be adjusted on serialisation
         # to match the `id` values required by Activity Stream.
+        # NOTE: check other relations, such as ManyToMany, just in case any show up in future models.
         foreign_key_fields = [
             [field.name, field.related_model.__name__]
             for field in fields
-            if field.is_relation and field.many_to_one
+            if field.is_relation and (field.many_to_one or field.one_to_one)
         ]
-        # NOTE: check other relations, such as ManyToMany, just in case any show up in future models.
         # Get all non-foreign-key field names so they can be serialised by the database.
         field_names = [
-            field.name for field in fields if not field.is_relation or field.many_to_one
+            field.name
+            for field in fields
+            if not field.is_relation or (field.many_to_one or field.one_to_one)
         ]
         # `JSONObject` expects a dict of JSON names mapped to field names;
         # we just want all fields to have the same name in JSON as they do in the DB.

--- a/update_supply_chain_information/activity_stream/test/conftest.py
+++ b/update_supply_chain_information/activity_stream/test/conftest.py
@@ -15,11 +15,14 @@ from supply_chains.models import (
     StrategicAction,
     StrategicActionQuerySet,
     StrategicActionUpdate,
+    ScenarioAssessment,
+    ScenarioAssessmentQuerySet,
 )
 from supply_chains.test.factories import (
     StrategicActionUpdateFactory,
     SupplyChainFactory,
     StrategicActionFactory,
+    ScenarioAssessmentFactory,
 )
 
 
@@ -66,6 +69,15 @@ def strategic_action_queryset(
             mock_now.return_value = last_modified
             StrategicActionFactory(supply_chain=supply_chain)
     return StrategicAction.objects.all()
+
+
+@pytest.fixture(scope="function")
+def scenario_assessment_queryset(last_modified_times) -> ScenarioAssessmentQuerySet:
+    supply_chain = SupplyChainFactory(name="SA OneToOne Test Supply Chain")
+    with mock.patch("django.utils.timezone.now") as mock_now:
+        mock_now.return_value = last_modified_times[0]
+        ScenarioAssessmentFactory(supply_chain=supply_chain)
+    return ScenarioAssessment.objects.all()
 
 
 @pytest.fixture()

--- a/update_supply_chain_information/activity_stream/test/test_querysets.py
+++ b/update_supply_chain_information/activity_stream/test/test_querysets.py
@@ -26,6 +26,15 @@ class TestActivityStreamQuerySetMixin:
         assert "supply_chain" == foreign_keys[0][0]
         assert "SupplyChain" == foreign_keys[0][1]
 
+    def test_activity_stream_queryset_includes_one_to_one_field_in_foreign_keys_information(
+        self, scenario_assessment_queryset
+    ):
+        instance = scenario_assessment_queryset.for_activity_stream().first()
+        assert "foreign_keys" in instance
+        foreign_keys = instance["foreign_keys"]["keys"]
+        assert "supply_chain" == foreign_keys[0][0]
+        assert "SupplyChain" == foreign_keys[0][1]
+
     def test_activity_stream_queryset_includes_object_type(
         self, strategic_action_queryset
     ):


### PR DESCRIPTION
The one-to-one relationship between `ScenarioAssessment` and `SupplyChain` was not represented in the activity stream. These commits adds support and tests.