### PR TITLE
RT-579: QuickSight link taken from Vault/environment.

### DIFF
--- a/cypress/integration/sap_details_spec.js
+++ b/cypress/integration/sap_details_spec.js
@@ -100,6 +100,11 @@ describe('The SAP details page', () => {
     cy.get('#action-details div.govuk-details__text dl.govuk-summary-list div dd.govuk-summary-list__value')
       .should('have.length', 7)
   })
+  it('shows the QuickSight link', () => {
+    cy.get('#app-quicksight-countries-link').should('exist')
+    cy.get('#app-quicksight-countries-link a[href]').should('exist').should('contain.text', "Strategic action progress")
+    cy.get('#app-quicksight-countries-link p.home-services-para').should('exist').should('contain.text', "Find out more about all strategic action progress and status history.")
+  })
 })
 
 const archivedAction = actions.filter(action => action.fields.name == "SA 007")[0]

--- a/cypress/integration/scd_info_spec.js
+++ b/cypress/integration/scd_info_spec.js
@@ -96,4 +96,9 @@ describe('The SCD info page', () => {
         })
       })
   })
+  it('shows the QuickSight link', () => {
+    cy.get('#app-quicksight-countries-link').should('exist')
+    cy.get('#app-quicksight-countries-link a[href]').should('exist').should('contain.text', "Country information")
+    cy.get('#app-quicksight-countries-link p.home-services-para').should('exist').should('contain.text', "Find out more about all country dependencies in relation to supply chain information.")
+  })
 })

--- a/update_supply_chain_information/action_progress/templates/action_progress_details.html
+++ b/update_supply_chain_information/action_progress/templates/action_progress_details.html
@@ -24,6 +24,19 @@
 {% include "includes/action_details.html" %}
 
 <br>
+{% with qs_sap_link="https://data.trade.gov.uk/visualisations/link/6a51d70e-08e7-42cd-98d9-e5bb4c1db430" %}
+    <div class="govuk-grid-column-one-half govuk-!-padding-left-0" id="app-quicksight-countries-link">
+        <ul class="govuk-list">
+            <li>
+                <a href="{{ qs_sap_link }}" class="services-heading govuk-link govuk-!-font-weight-bold">Strategic action progress</a>
+
+                <p class="home-services-para">
+                    Find out more about all strategic action progress and status history.
+                </p>
+            </li>
+        </ul>
+    </div>
+{% endwith %}
 <br>
 <div class="app-back-to-top" data-module="app-back-to-top">
     <a class="govuk-link govuk-link--no-visited-state app-back-to-top__link" href="#top">

--- a/update_supply_chain_information/chain_details/templates/chain_details_info.html
+++ b/update_supply_chain_information/chain_details/templates/chain_details_info.html
@@ -1,5 +1,5 @@
 {% extends "chain_details_base.html" %}
-
+{% load supply_chain_tags %}
 
 {% block page_header %}
 
@@ -43,7 +43,20 @@
 {% include "includes/chain_stages.html" %}
 {% include "scenario_assessment.html" %}
 
-<br>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half" id="app-quicksight-countries-link">
+        <ul class="govuk-list">
+            <li>
+                <a href="{% quicksight_countries_dashboard_url %}" class="services-heading govuk-link govuk-!-font-weight-bold">Country information</a>
+
+                <p class="home-services-para">
+                    Find out more about all country dependencies in relation to supply chain information.
+                </p>
+            </li>
+        </ul>
+    </div>
+</div>
+    <br>
 
 
 <div class="app-back-to-top" data-module="app-back-to-top">
@@ -54,6 +67,5 @@
     </svg>Back to top
   </a>
 </div>
-
 
 {% endblock page_content %}

--- a/update_supply_chain_information/config/settings.py
+++ b/update_supply_chain_information/config/settings.py
@@ -252,3 +252,8 @@ HAWK_CREDENTIALS = {
     },
 }
 HAWK_MESSAGE_EXPIRATION = 60  # seconds until a Hawk header is regarded as expired
+
+# This value is set in Vault so it can be readily updated once the correct link is available
+QUICKSIGHT_COUNTRIES_DASHBOARD_URL = env.str(
+    "QUICKSIGHT_COUNTRIES_DASHBOARD_URL", default="about:blank"
+)

--- a/update_supply_chain_information/sample.env
+++ b/update_supply_chain_information/sample.env
@@ -26,5 +26,8 @@ SESSION_COOKIE_SECURE=False
 HAWK_UNIQUE_ID=activitystream_uniqueid
 HAWK_SECRET_ACCESS_KEY=activitystream_secret
 
+# Link to QuickSight country information dashboard.
+QUICKSIGHT_COUNTRIES_DASHBOARD_URL=https://data.trade.gov.uk/visualisations/link/2ade7245-2629-4dff-a2ff-d700b5a74807
+
 # First name of the user to elevate as admin
 #LOCAL_USER_FIRST_NAME=Prashanth

--- a/update_supply_chain_information/supply_chains/templates/base.html
+++ b/update_supply_chain_information/supply_chains/templates/base.html
@@ -50,13 +50,11 @@
                 Supply chain details
             </a>
         </li>
-        {% with qs_ci_link="https://data.trade.gov.uk/visualisations/link/6a51d70e-08e7-42cd-98d9-e5bb4c1db430" %}
         <li class="govuk-header__navigation-item">
-            <a class="govuk-header__link" href="{{ qs_ci_link }}">
+            <a class="govuk-header__link" href="{% quicksight_countries_dashboard_url %}">
                 Country information
             </a>
         </li>
-        {% endwith %}
     </ul>
 </nav>
 {% endblock menu_header %}

--- a/update_supply_chain_information/supply_chains/templates/index.html
+++ b/update_supply_chain_information/supply_chains/templates/index.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load supply_chain_tags %}
 
 {% block body %}
 <h1 class="govuk-heading-xl" style="margin-bottom: 15px;">UK supply chain<br>resilience tool</h1>
@@ -76,11 +77,10 @@
             </li>
         </ul>
     </div>
-    {% with qs_ci_link="https://data.trade.gov.uk/visualisations/link/6a51d70e-08e7-42cd-98d9-e5bb4c1db430" %}
     <div class="govuk-grid-column-one-half">
         <ul class="govuk-list">
             <li>
-                <a href="{{ qs_ci_link }}" class="services-heading govuk-link govuk-!-font-weight-bold">Country information</a>
+                <a href="{% quicksight_countries_dashboard_url %}" class="services-heading govuk-link govuk-!-font-weight-bold">Country information</a>
 
                 <p class="home-services-para">
                     Find out more about all country dependencies in relation to supply chain information.
@@ -88,7 +88,6 @@
             </li>
         </ul>
     </div>
-    {% endwith %}
 
 </div>
 

--- a/update_supply_chain_information/supply_chains/templatetags/supply_chain_tags.py
+++ b/update_supply_chain_information/supply_chains/templatetags/supply_chain_tags.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.template.defaulttags import register
 from django.urls import reverse
 
@@ -42,3 +43,8 @@ def get_active_menu(context):
         menu = "home"
 
     return menu
+
+
+@register.simple_tag(takes_context=False)
+def quicksight_countries_dashboard_url():
+    return settings.QUICKSIGHT_COUNTRIES_DASHBOARD_URL


### PR DESCRIPTION
Include country information (configured in environment) and strategic… action progress Quicksight links.

This needs
```
QUICKSIGHT_COUNTRIES_DASHBOARD_URL=https://data.trade.gov.uk/visualisations/link/2ade7245-2629-4dff-a2ff-d700b5a74807
``` in .env, otherwise the links will be to `about:blank`.